### PR TITLE
Set default timeouts for TLS and transport along with closing HTTP client connections.

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ type SplunkbotOptions struct {
 	TLSHandshakeTimeout  uint   `short:"h" long:"tls-timeout" description:"TLS Handshake timeout (seconds)" env:"SPLUNKBOT_TLS_TIMEOUT" default:"5"`
 	TransportDialTimeout uint   `short:"d" long:"dial-timeout" description:"Transport Dial timeout (seconds)" env:"SPLUNKBOT_DIAL_TIMEOUT" default:"5"`
 	SplunkUrl            string `short:"u" long:"splunk-url" description:"Splunk HEC endpoint" env:"SPLUNKBOT_SPLUNK_URL" required:"true"`
-	SplunkHTTPTimeout    uint   `short:"n" long:"splunk-timeout" description:"Splunk HEC timeout (seconds)" env:"SPLUNKBOT_SPLUNK_HTTP_TIMEOUT" default:"5"`
+	SplunkHTTPTimeout    uint   `short:"n" long:"splunk-timeout" description:"Splunk HEC timeout (seconds)" env:"SPLUNKBOT_SPLUNK_HTTP_TIMEOUT" default:"10"`
 	SplunkToken          string `short:"t" long:"splunk-token" description:"Splunk HEC token" env:"SPLUNKBOT_SPLUNK_TOKEN" required:"true"`
 	SplunkIndex          string `short:"i" long:"splunk-index" description:"Splunk index" env:"SPLUNKBOT_SPLUNK_INDEX"`
 	SplunkSourcetype     string `short:"s" long:"splunk-sourcetype" description:"Splunk event sourcetype" env:"SPLUNKBOT_SPLUNK_SOURCETYPE" required:"true" default:"alertmanager"`

--- a/splunkbot/splunkbot.go
+++ b/splunkbot/splunkbot.go
@@ -71,6 +71,7 @@ func (sbot Splunkbot) alert(w http.ResponseWriter, r *http.Request) {
 	jr := bytes.NewReader(j)
 
 	splunkReq, _ := http.NewRequest("POST", sbot.SplunkUrl, jr)
+  splunkReq.Close = true
 	splunkReq.Header.Set("Authorization", "Splunk "+sbot.SplunkToken)
 
 	// Do request

--- a/splunkbot/splunkbot.go
+++ b/splunkbot/splunkbot.go
@@ -94,5 +94,6 @@ func (sbot Splunkbot) alert(w http.ResponseWriter, r *http.Request) {
 		w.Write(buf)
 	}
 
+	defer resp.Body.Close()
 	log.Debugf("End of request")
 }

--- a/splunkbot/splunkbot.go
+++ b/splunkbot/splunkbot.go
@@ -71,7 +71,7 @@ func (sbot Splunkbot) alert(w http.ResponseWriter, r *http.Request) {
 	jr := bytes.NewReader(j)
 
 	splunkReq, _ := http.NewRequest("POST", sbot.SplunkUrl, jr)
-  splunkReq.Close = true
+	splunkReq.Close = true
 	splunkReq.Header.Set("Authorization", "Splunk "+sbot.SplunkToken)
 
 	// Do request


### PR DESCRIPTION
During multiple individual alerts firing, the http request was being re-used which resulted in an EOF response to splunkbot. This then fires the 503 back to alertmanager which isn't ideal.

Tested and confirmed alerts still flow to splunk with this change and no longer receive the EOF message.